### PR TITLE
feat: CommonCard컴포넌트 생성 및 Plan페이지 모바일 뷰에서 카드 리스트로 보이도록 구현 #189

### DIFF
--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import CommonButton from "./common-button";
 import Link from "next/link";
+import { IPlanData } from "@/types/grid-col";
 
 interface PlanMobileCardProps {
   id: string;
@@ -9,6 +10,9 @@ interface PlanMobileCardProps {
   importer: string;
   contractDate: string;
   item: string;
+  isSelected: boolean;
+  onSelect: (rowData: IPlanData) => void;
+  rowData: IPlanData;
 }
 
 export default function PlanMobileCard({
@@ -17,17 +21,47 @@ export default function PlanMobileCard({
   importer,
   contractDate,
   item,
+  isSelected,
+  onSelect,
+  rowData,
 }: PlanMobileCardProps) {
+  const handleCardClick = (e: React.MouseEvent) => {
+    // 상세보기 버튼 클릭은 제외
+    if ((e.target as HTMLElement).closest("a")) {
+      return;
+    }
+    onSelect(rowData);
+  };
+
   return (
-    <div className="rounded-xl border border-gray-300 bg-white p-4 mb-3 shadow-sm flex flex-col">
-      <div className="font-semibold text-gray-800 mb-1">
-        계약번호: {contractNo}
+    <div
+      className={`rounded-xl border p-4 mb-3 shadow-sm flex flex-col cursor-pointer transition-all duration-200 ${
+        isSelected
+          ? "border-[#22C55E] bg-[#22C55E]/10"
+          : "border-gray-300 bg-white hover:border-gray-400"
+      }`}
+      onClick={handleCardClick}
+    >
+      {/* 체크박스와 계약번호 */}
+      <div className="flex items-center mb-1">
+        <input
+          type="checkbox"
+          hidden={true}
+          checked={isSelected}
+          onChange={() => onSelect(rowData)}
+          className="mr-3 h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+          onClick={(e) => e.stopPropagation()}
+        />
+        <div className="font-semibold text-gray-800">
+          계약번호: {contractNo}
+        </div>
       </div>
+
       <div className="flex justify-between">
         <div className="flex flex-col">
-          <div className="text-sm text-gray-600 ">수입회사: {importer}</div>
-          <div className="text-sm text-gray-600 ">계약일자: {contractDate}</div>
-          <div className="text-sm text-gray-600 ">품목명: {item}</div>
+          <div className="text-sm text-gray-600">수입회사: {importer}</div>
+          <div className="text-sm text-gray-600">계약일자: {contractDate}</div>
+          <div className="text-sm text-gray-600">품목명: {item}</div>
         </div>
         <div className="flex justify-end items-end">
           <Link href={`/detail/${id}`}>

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,30 +1,38 @@
-// PlanMobileCard.tsx
 import React from "react";
-import CommonButton from "./common-button";
 import Link from "next/link";
-import { IPlanData } from "@/types/grid-col";
+import CommonButton from "./common-button";
 
-interface PlanMobileCardProps {
-  id: string;
-  contractNo: string;
-  importer: string;
-  contractDate: string;
-  item: string;
-  isSelected: boolean;
-  onSelect: (rowData: IPlanData) => void;
-  rowData: IPlanData;
+// 카드에 표시할 필드 정의
+interface CardField {
+  label: string;
+  value: string | number;
 }
 
-export default function PlanMobileCard({
-  id,
-  contractNo,
-  importer,
-  contractDate,
-  item,
+// 선택 가능한 아이템의 최소 요구사항
+interface SelectableItem {
+  id: string;
+}
+
+interface CommonCardProps<T extends SelectableItem> {
+  id: string;
+  title: string; // 카드 제목 (예: "계약번호: CONTRACT-001")
+  fields: CardField[]; // 표시할 필드들
+  isSelected: boolean;
+  onSelect: (rowData: T) => void;
+  rowData: T;
+  detailHref?: string; // 상세 페이지 링크 (선택사항)
+  detailButtonText?: string; // 버튼 텍스트 커스텀
+}
+
+export default function CommonCard<T extends SelectableItem>({
+  title,
+  fields,
   isSelected,
   onSelect,
   rowData,
-}: PlanMobileCardProps) {
+  detailHref,
+  detailButtonText = "상세보기",
+}: CommonCardProps<T>) {
   const handleCardClick = (e: React.MouseEvent) => {
     // 상세보기 버튼 클릭은 제외
     if ((e.target as HTMLElement).closest("a")) {
@@ -42,7 +50,7 @@ export default function PlanMobileCard({
       }`}
       onClick={handleCardClick}
     >
-      {/* 체크박스와 계약번호 */}
+      {/* 체크박스와 제목 */}
       <div className="flex items-center mb-1">
         <input
           type="checkbox"
@@ -52,22 +60,25 @@ export default function PlanMobileCard({
           className="mr-3 h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
           onClick={(e) => e.stopPropagation()}
         />
-        <div className="font-semibold text-gray-800">
-          계약번호: {contractNo}
-        </div>
+        <div className="font-semibold text-gray-800">{title}</div>
       </div>
 
       <div className="flex justify-between">
         <div className="flex flex-col">
-          <div className="text-sm text-gray-600">수입회사: {importer}</div>
-          <div className="text-sm text-gray-600">계약일자: {contractDate}</div>
-          <div className="text-sm text-gray-600">품목명: {item}</div>
+          {fields.map((field) => (
+            <div key={field.label} className="text-sm text-gray-600">
+              {field.label}: {field.value}
+            </div>
+          ))}
         </div>
-        <div className="flex justify-end items-end">
-          <Link href={`/detail/${id}`}>
-            <CommonButton variant="primary">상세보기</CommonButton>
-          </Link>
-        </div>
+
+        {detailHref && (
+          <div className="flex justify-end items-end">
+            <Link href={detailHref}>
+              <CommonButton variant="primary">{detailButtonText}</CommonButton>
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,0 +1,40 @@
+// PlanMobileCard.tsx
+import React from "react";
+import CommonButton from "./common-button";
+import Link from "next/link";
+
+interface PlanMobileCardProps {
+  id: string;
+  contractNo: string;
+  importer: string;
+  contractDate: string;
+  item: string;
+}
+
+export default function PlanMobileCard({
+  id,
+  contractNo,
+  importer,
+  contractDate,
+  item,
+}: PlanMobileCardProps) {
+  return (
+    <div className="rounded-xl border border-gray-300 bg-white p-4 mb-3 shadow-sm flex flex-col">
+      <div className="font-semibold text-gray-800 mb-1">
+        계약번호: {contractNo}
+      </div>
+      <div className="flex justify-between">
+        <div className="flex flex-col">
+          <div className="text-sm text-gray-600 ">수입회사: {importer}</div>
+          <div className="text-sm text-gray-600 ">계약일자: {contractDate}</div>
+          <div className="text-sm text-gray-600 ">품목명: {item}</div>
+        </div>
+        <div className="flex justify-end items-end">
+          <Link href={`/detail/${id}`}>
+            <CommonButton variant="primary">상세보기</CommonButton>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plan-grid.tsx
+++ b/src/components/plan-grid.tsx
@@ -24,6 +24,8 @@ import { DetailButtonRenderer } from "./cell-renderers";
 import { selectedCargosAtom } from "@/states/plan";
 import { useSetAtom } from "jotai";
 import { ColumnOrder } from "@/actions/user";
+import { useMediaQuery } from "@mui/material";
+import PlanMobileCard from "./card";
 // 컬럼 드래그 커스텀 훅
 
 export default function PlanGrid() {
@@ -31,6 +33,8 @@ export default function PlanGrid() {
   const [columnOrder, setColumnOrder] = useState<ColumnOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const isMobile = useMediaQuery("(max-width: 767px)");
 
   // 컬럼 정의
   const columnDefs = useMemo<ColDef[]>(() => {
@@ -125,6 +129,7 @@ export default function PlanGrid() {
       try {
         setLoading(true);
         const data = await getPlanData();
+        console.log("data", data);
         const userColumnOrder = await getUserPlanColumnOrder();
         setRowData(data);
         setColumnOrder(userColumnOrder || defaultPlanColumnOrderFields);
@@ -152,7 +157,20 @@ export default function PlanGrid() {
     [setSelectedRows],
   );
 
-  return (
+  return isMobile ? (
+    <div className="flex flex-col gap-1">
+      {rowData.map((row) => (
+        <PlanMobileCard
+          key={row.id}
+          id={row.id}
+          contractNo={row.contractNumber}
+          importer={row.importer}
+          contractDate={row.contractDate}
+          item={row.itemName}
+        />
+      ))}
+    </div>
+  ) : (
     <FilterGrid
       columnDefs={columnDefs}
       data={rowData}

--- a/src/components/plan-grid.tsx
+++ b/src/components/plan-grid.tsx
@@ -23,7 +23,7 @@ import FilterGrid from "./filter-grid";
 import { DetailButtonRenderer } from "./cell-renderers";
 import { ColumnOrder } from "@/actions/user";
 import { useMediaQuery } from "@mui/material";
-import PlanMobileCard from "./card";
+import CommonCard from "./card";
 
 export default function PlanGrid() {
   const [rowData, setRowData] = useState<IPlanData[]>([]);
@@ -184,16 +184,19 @@ export default function PlanGrid() {
   return isMobile ? (
     <div className="flex flex-col gap-1">
       {rowData.map((row) => (
-        <PlanMobileCard
+        <CommonCard
           key={row.id}
           id={row.id}
-          contractNo={row.contractNumber}
-          importer={row.importer}
-          contractDate={row.contractDate}
-          item={row.itemName}
+          title={`계약번호: ${row.contractNumber}`}
+          fields={[
+            { label: "수입회사", value: row.importer },
+            { label: "계약일자", value: row.contractDate },
+            { label: "품목명", value: row.itemName },
+          ]}
           isSelected={isCardSelected(row.id)}
           onSelect={handleMobileCardSelect}
           rowData={row}
+          detailHref={`/detail/${row.id}`}
         />
       ))}
     </div>

--- a/src/containers/plan/cargo-delete-modal.tsx
+++ b/src/containers/plan/cargo-delete-modal.tsx
@@ -5,7 +5,7 @@ import DialogActions from "@mui/material/DialogActions";
 
 import { deletePlans } from "@/actions/plan";
 import { useAtomValue, useSetAtom } from "jotai";
-import { cargoRefreshAtom, selectedCargosAtom } from "@/states/plan";
+import { cargoRefreshAtom, selectedPlanRowsAtom } from "@/states/plan";
 import CommonButton from "@/components/common-button";
 
 // 계획 삭제 확인 모달 컴포넌트
@@ -18,7 +18,7 @@ export function CargoDeleteConfirmModal({
   open,
   onClose,
 }: CargoDeleteConfirmModalProps) {
-  const selectedRows = useAtomValue(selectedCargosAtom);
+  const selectedRows = useAtomValue(selectedPlanRowsAtom);
   const setRefresh = useSetAtom(cargoRefreshAtom);
 
   async function onConfirm() {

--- a/src/containers/plan/plan.tsx
+++ b/src/containers/plan/plan.tsx
@@ -3,7 +3,7 @@
 import PlanGrid from "@/components/plan-grid";
 import PlanButton from "./plan-button";
 import { useAtom } from "jotai";
-import { selectedCargosAtom } from "@/states/plan";
+import { selectedPlanRowsAtom } from "@/states/plan";
 import { useEffect, useState } from "react";
 import { CargoDeleteConfirmModal } from "@/containers/plan/cargo-delete-modal";
 import Stack from "@mui/material/Stack";
@@ -11,7 +11,7 @@ import CommonButton from "@/components/common-button";
 
 export default function Plan() {
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
-  const [selectedRows, setSelectedRows] = useAtom(selectedCargosAtom);
+  const [selectedRows, setSelectedRows] = useAtom(selectedPlanRowsAtom);
 
   useEffect(() => {
     // 페이지 진입 시 선택된 행 초기화

--- a/src/states/plan.ts
+++ b/src/states/plan.ts
@@ -1,11 +1,15 @@
 import { atom } from "jotai";
 import { InferSelectModel } from "drizzle-orm";
 import { cargos } from "@/db/schema";
+import { IPlanData } from "@/types/grid-col";
 
 export type CargoRow = InferSelectModel<typeof cargos>;
 
 // 선택된 사업자등록번호 목록을 관리하는 atom
 export const selectedCargosAtom = atom<CargoRow[]>([]);
+
+// 선택된 계획 현황 목록을 관리하는 atom
+export const selectedPlanRowsAtom = atom<IPlanData[]>([]);
 
 // 화물 목록 새로고침을 위한 atom
 export const cargoRefreshAtom = atom<number>(0);

--- a/src/types/grid-col.ts
+++ b/src/types/grid-col.ts
@@ -24,6 +24,7 @@ export interface IShipmentData {
 }
 
 export interface IPlanData {
+  id: string;
   contractNumber: string;
   progressStatus: string;
   contractDate: string;


### PR DESCRIPTION
<!-- PR의 제목은 [Label]: [Title] [Issue Number] 형식으로 작성해 주세요. 예시: feat: 채팅 기능 추가 #33 -->

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인해 주세요:

- [x] `.github/conventions.md`의 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다. (for bug fixes / features)
- [ ] 문서가 추가되었거나 업데이트 되었습니다. (for bug fixes / features)

## What is the current behavior?

<!-- 수정 중인 현재 동작을 설명하거나 관련된 이슈에 대한 링크를 추가해 주세요. -->

Issue Number: #189 

## What is the new behavior?

- plan페이지 모바일 뷰에서 그리드 대신 카드 리스트로 보이도록 수정했습니다.
- plan페이지의 선택 상태를 CargoRow에서 IPlanData로 변경했습니다.
- Card컴포넌트를 어느 페이지에서 재사용 가능하도록 구현했습니다.

## Does this PR introduce a breaking change?

- [] Yes
- [] No

<!-- 이 PR에 호환성에 영향을 미치는 변경 사항이 포함된 경우, 기존 애플리케이션에 미치는 영향과 마이그레이션 경로를 아래에 설명해 주세요. -->

## Other information
